### PR TITLE
Payments: enable 30 day trial of PRO version

### DIFF
--- a/backend/pkg/controllers/payments.controller.go
+++ b/backend/pkg/controllers/payments.controller.go
@@ -71,6 +71,9 @@ func (pc *PaymentController) UpgradeProHandler(ctx *gin.Context) {
 		PaymentMethodTypes: stripe.StringSlice([]string{
 			"card",
 		}),
+		SubscriptionData: &stripe.CheckoutSessionSubscriptionDataParams{
+			TrialPeriodDays: stripe.Int64(30),
+		},
 		SuccessURL: stripe.String(fmt.Sprintf("%s?session_id={CHECKOUT_SESSION_ID}", requestData.SuccessUrl)),
 	}
 	if stripeCustomer != nil {


### PR DESCRIPTION
User will get 30-day trial after providing her/his card details, after that period she/he will be charged

Resolves the BE part of the #59 